### PR TITLE
Change Appcast feed

### DIFF
--- a/sketch_translate.sketchplugin/Contents/Sketch/manifest.json
+++ b/sketch_translate.sketchplugin/Contents/Sketch/manifest.json
@@ -2,7 +2,7 @@
     "name" : "Texts Translation",
     "identifier" : "com.sketchapp.examples.sketch-translate",
     "version" : "0.1.3",
-    "appcast": "https://raw.githubusercontent.com/laresgoiti/texts_translate/master/appcast.xml",
+    "appcast": "https://api.sketchpacks.com/v1/plugins/com.sketchapp.examples.sketch-translate/appcast",
     "description" : "Texts translation in Sketch",
     "authorEmail" : "slaresgoiti@gmail.com",
     "author" : "Santi Laresgoiti Navarro",


### PR DESCRIPTION
You can use the Sketchpacks Appcast API to serve [your appcast feed](https://api.sketchpacks.com/v1/plugins/com.sketchapp.examples.sketch-translate/appcast). It automatically serves your published releases.

Downloads and updates served via Sketchpacks or the Appcast feed affects [your download and update metrics](https://api.sketchpacks.com/v1/plugins/com.sketchapp.examples.sketch-translate/rollup).